### PR TITLE
Force wget always to write the same file name

### DIFF
--- a/luaver
+++ b/luaver
@@ -156,12 +156,13 @@ __luaver_exists()
 __luaver_download()
 {
     local url=$1
+    local filename=${url##*/}
 
     __luaver_print "Downloading from ${url}"
 
     if __luaver_exists "wget"
     then
-        __luaver_exec_command "wget ${url}"
+        __luaver_exec_command "wget -O ${filename} ${url}"
     else
         __luaver_error "'wget' must be installed"
     fi


### PR DESCRIPTION
`luaver install` stop working when the download process fails previously because of wget's renaming.

```
$ luaver install 5.2.4
==>  Installing lua-5.2.4
==>  Detecting already downloaded archives
==>  Downloading lua-5.2.4
==>  Downloading from http://www.lua.org/ftp/lua-5.2.4.tar.gz
--- snip ---
lua-5.2.4.tar.gz      8%[>                   ]  21.50K  70.0KB/s               ^C
Unable to execute the following command:
wget http://www.lua.org/ftp/lua-5.2.4.tar.gz
Exiting

$ luaver install 5.2.4
==>  Installing lua-5.2.4
==>  Detecting already downloaded archives
==>  Downloading lua-5.2.4
==>  Downloading from http://www.lua.org/ftp/lua-5.2.4.tar.gz
--- snip ---
Saving to: ‘lua-5.2.4.tar.gz.1’

lua-5.2.4.tar.gz.1  100%[===================>] 246.73K   127KB/s    in 1.9s

2016-11-07 23:32:14 (127 KB/s) - ‘lua-5.2.4.tar.gz.1’ saved [252651/252651]

==>  Download successful
==>  Extracting archive
==>  Unpacking lua-5.2.4.tar.gz
--- snip ---
x lua-5.2.4/src/lstate.h: (Empty error message)
tar: Error exit delayed from previous errors.
Unable to execute the following command:
tar xvzf lua-5.2.4.tar.gz
Exiting
```

This changes prevent this happening by supplying `-O filename` to wget.