### PR TITLE
Portability issues

### DIFF
--- a/luaver
+++ b/luaver
@@ -65,6 +65,20 @@ __luaver_exec_command()
     fi
 }
 
+# Return the correct make utility for this OS
+__luaver_get_make_tool()
+{
+    # Care for make tool compatibility
+    # If OS is *BSD, require gmake
+    if [[ $OSTYPE =~ linux ]]
+    then
+        echo "make"
+    elif [[ $OSTYPE =~ bsd ]]
+    then
+        echo "gmake"
+    fi
+    # TODO check MacOS compatibility
+}
 # Perform some initialization
 __luaver_init()
 {
@@ -419,7 +433,7 @@ __luaver_install_lua()
 
     __luaver_print "Compiling ${lua_dir_name}"
 
-    __luaver_exec_command "make ${platform} install INSTALL_TOP=${__luaver_LUA_DIR}/${version}"
+    __luaver_exec_command "$(__luaver_get_make_tool) ${platform} install INSTALL_TOP=${__luaver_LUA_DIR}/${version}"
 
     read -r -p "${lua_dir_name} successfully installed. Do you want to switch to this version? [Y/n]: " choice
     case $choice in
@@ -545,8 +559,8 @@ __luaver_install_luajit()
 
     __luaver_print "Compiling ${luajit_dir_name}"
 
-    __luaver_exec_command "make PREFIX=${__luaver_LUAJIT_DIR}/${version}"
-    __luaver_exec_command "make install PREFIX=${__luaver_LUAJIT_DIR}/${version}"
+    __luaver_exec_command "$(__luaver_get_make_tool) PREFIX=${__luaver_LUAJIT_DIR}/${version}"
+    __luaver_exec_command "$(__luaver_get_make_tool) install PREFIX=${__luaver_LUAJIT_DIR}/${version}"
 
     read -r -p "${luajit_dir_name} successfully installed. Do you want to switch to this version? [Y/n]: " choice
     case $choice in
@@ -671,8 +685,8 @@ __luaver_install_luarocks()
                         --with-lua-lib=${__luaver_LUA_DIR}/${lua_version}/lib
                         --versioned-rocks-dir"
 
-    __luaver_exec_command "make build"
-    __luaver_exec_command "make install"
+    __luaver_exec_command "$(__luaver_get_make_tool) build"
+    __luaver_exec_command "$(__luaver_get_make_tool) install"
 
     read -r -p "${luarocks_dir_name} successfully installed. Do you want to switch to this version? [Y/n]: " choice
     case $choice in

--- a/luaver
+++ b/luaver
@@ -225,7 +225,7 @@ __luaver_download_and_unpack()
         read -r -p "${unpack_dir_name} has already been downloaded. Download again? [Y/n]: " choice
         case $choice in
             [yY][eE][sS] | [yY] )
-                __luaver_exec_command "rm -r ${unpack_dir_name}"
+                __luaver_exec_command "rm -fr ${unpack_dir_name}"
                 ;;
         esac
     fi
@@ -237,7 +237,7 @@ __luaver_download_and_unpack()
         __luaver_download $url
         __luaver_print "Extracting archive"
         __luaver_unpack $archive_name
-        __luaver_exec_command "rm ${archive_name}"
+        __luaver_exec_command "rm -f ${archive_name}"
     fi
 }
 
@@ -275,7 +275,7 @@ __luaver_uninstall()
         __luaver_error "${package_name} is not installed"
     fi
 
-    __luaver_exec_command 'rm -r "${package_dir}"'
+    __luaver_exec_command 'rm -fr "${package_dir}"'
 
     __luaver_print "Successfully uninstalled ${package_name}"
 }
@@ -511,7 +511,7 @@ __luaver_set_default_lua()
 
 __luaver_unset_default_lua()
 {
-    __luaver_exec_command "rm ${__luaver_LUA_DEFAULT_FILE}"
+    __luaver_exec_command "rm -f ${__luaver_LUA_DEFAULT_FILE}"
     __luaver_print "Removed default version for lua"
 }
 
@@ -620,7 +620,7 @@ __luaver_set_default_luajit()
 
 __luaver_unset_default_luajit()
 {
-    __luaver_exec_command "rm ${__luaver_LUAJIT_DEFAULT_FILE}"
+    __luaver_exec_command "rm -f ${__luaver_LUAJIT_DEFAULT_FILE}"
     __luaver_print "Removed default version for LuaJIT"
 }
 
@@ -756,7 +756,7 @@ __luaver_set_default_luarocks()
 
 __luaver_unset_default_luarocks()
 {
-    __luaver_exec_command "rm ${__luaver_LUAROCKS_DEFAULT_FILE}"
+    __luaver_exec_command "rm -f ${__luaver_LUAROCKS_DEFAULT_FILE}"
     __luaver_print "Removed default version for luarocks"
 }
 

--- a/luaver
+++ b/luaver
@@ -39,7 +39,7 @@ __luaver_error()
 # Printing bold text - TODO
 __luaver_print()
 {
-    if [ ! $__luaver_verbose == 0 ]
+    if [ ! $__luaver_verbose = 0 ]
     then
         tput bold
         printf "==>  $1\n"
@@ -121,7 +121,7 @@ __luaver_init()
 # Checking whether a particular tool exists or not
 __luaver_exists()
 {
-    if [ "$1" == "lua" ]
+    if [ "$1" = "lua" ]
     then
         if [[ $(which lua) == ${__luaver_LUA_DIR}* ]]
         then
@@ -130,7 +130,7 @@ __luaver_exists()
             return 1
         fi
     fi
-    if [ "$1" == "luajit" ]
+    if [ "$1" = "luajit" ]
     then
         if [[ $(which luajit) == ${__luaver_LUAJIT_DIR}* ]]
         then
@@ -139,7 +139,7 @@ __luaver_exists()
             return 1
         fi
     fi
-    if [ "$1" == "luarocks" ]
+    if [ "$1" = "luarocks" ]
     then
         if [[ $(which luarocks) == ${__luaver_LUAROCKS_DIR}* ]]
         then
@@ -499,7 +499,7 @@ __luaver_uninstall_lua()
 
     __luaver_uninstall $lua_name $__luaver_LUA_DIR $version
 
-    if [ "${version}" == "${current_version}" ]
+    if [ "${version}" = "${current_version}" ]
     then
         __luaver_remove_previous_paths "${__luaver_LUA_DIR}"
     fi
@@ -518,7 +518,7 @@ __luaver_list_lua()
         __luaver_print "Installed versions: "
         for version in "${installed_versions[@]}"
         do
-            if [ "${version}" == "${current_version}" ]
+            if [ "${version}" = "${current_version}" ]
             then
                 __luaver_print "lua-${version} <--"
             else 
@@ -608,7 +608,7 @@ __luaver_uninstall_luajit()
 
     __luaver_uninstall $luajit_name $__luaver_LUAJIT_DIR $version
 
-    if [ "${version}" == "${current_version}" ]
+    if [ "${version}" = "${current_version}" ]
     then
         __luaver_remove_previous_paths "${__luaver_LUAJIT_DIR}"
     fi
@@ -627,7 +627,7 @@ __luaver_list_luajit()
         __luaver_print "Installed versions: "
         for version in "${installed_versions[@]}"
         do
-            if [ "${version}" == "${current_version}" ]
+            if [ "${version}" = "${current_version}" ]
             then
                 __luaver_print "LuaJIT-${version} <--"
             else
@@ -641,7 +641,7 @@ __luaver_install_luarocks()
 {
     # Checking whether any version of lua is installed or not
     __luaver_get_current_lua_version lua_version
-    if [ "" == "${lua_version}" ]
+    if [ "" = "${lua_version}" ]
     then
         __luaver_error "No lua version set"
     fi
@@ -689,7 +689,7 @@ __luaver_use_luarocks()
 
     __luaver_get_current_lua_version_short lua_version
 
-    if [ "${lua_version}" == "" ]
+    if [ "${lua_version}" = "" ]
     then
         __luaver_error "You need to first switch to a lua installation"
     fi
@@ -747,7 +747,7 @@ __luaver_uninstall_luarocks()
 
     __luaver_uninstall $luarocks_name $__luaver_LUAROCKS_DIR "${version}_${lua_version}"
 
-    if [ "${version}" == "${current_version}" ]
+    if [ "${version}" = "${current_version}" ]
     then
         __luaver_remove_previous_paths "${__luaver_LUAROCKS_DIR}"
     fi
@@ -770,7 +770,7 @@ __luaver_list_luarocks()
             luarocks_version=${version%_*}
             lua_version=${version#*_}
 
-            if [ "${luarocks_version}" == "${current_luarocks_version}" ] && [ "${lua_version}" == "${current_lua_version}" ]
+            if [ "${luarocks_version}" = "${current_luarocks_version}" ] && [ "${lua_version}" = "${current_lua_version}" ]
             then
                 __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version}) <--"
             else
@@ -788,15 +788,15 @@ __luaver_current()
 
     __luaver_print "Current versions:"
 
-    if [ ! "${lua_version}" == "" ]
+    if [ ! "${lua_version}" = "" ]
     then
         __luaver_print "lua-${lua_version}"
     fi
-    if [ ! "${luajit_version}" == "" ]
+    if [ ! "${luajit_version}" = "" ]
     then
         __luaver_print "LuaJIT-${luajit_version}"
     fi
-    if [ ! "${luarocks_version}" == "" ]
+    if [ ! "${luarocks_version}" = "" ]
     then
         __luaver_print "luarocks-${luarocks_version}"
     fi

--- a/luaver
+++ b/luaver
@@ -79,6 +79,17 @@ __luaver_get_make_tool()
     fi
     # TODO check MacOS compatibility
 }
+
+# Check whether required tools are installed
+# Argument is a list of tools required for LuaVer to work properly
+__luaver_check_requirements()
+{
+    for tool in "$@"
+    do
+        command -v $tool &> /dev/null || __luaver_error "LuaVer: $tool is required"
+    done
+}
+
 # Perform some initialization
 __luaver_init()
 {
@@ -824,6 +835,7 @@ __luaver_version()
 
 # Init environment
 __luaver_init
+__luaver_check_requirements $(__luaver_get_make_tool)
 
 luaver()
 {


### PR DESCRIPTION
Hey Dhaval,

Some commits:

143f885  add -f flag to `rm`: this one is for usability; if one has rm aliased to -i to avoid deleting personal important files, it may be annoying to uninstall Lua versions
since `rm` will prompt for every file in the distribution
521e03d  add function to check for required tools
5979019  select correct `make` utility based on OS; needed to make it work transparently in *BSD systems
21fa7e1   replace `==` by `=` in conditionals; needed to make it work in more shells -- if I'm not mistaken, `==` is a bashism, `=` is the POSIX way.

Please let me know of any issue or comment.