### PR TITLE
Fix quoting around wget

### DIFF
--- a/luaver
+++ b/luaver
@@ -158,7 +158,7 @@ __luaver_download()
 
     if __luaver_exists "wget"
     then
-        __luaver_exec_command wget -O "${filename} ${url}"
+        __luaver_exec_command wget -O "${filename}" "${url}"
     elif __luaver_exists "curl"
     then
         __luaver_exec_command curl -fLO "${url}"


### PR DESCRIPTION
Related #25 
This should fix this missing URL error of wget.

```
$ luaver install 5.3.1
==>  Installing lua-5.3.1
==>  Detecting already downloaded archives
==>  lua-5.3.1 has already been downloaded. Download again? [Y/n]:
y
==>  Downloading lua-5.3.1
==>  Downloading from http://www.lua.org/ftp/lua-5.3.1.tar.gz
wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.
Unable to execute the following command:
wget
Exiting
```