### PR TITLE
Remove fragile ls

### DIFF
--- a/luaver
+++ b/luaver
@@ -512,7 +512,7 @@ __luaver_uninstall_lua()
 
 __luaver_list_lua()
 {
-    __luaver_print "Installed versions: (currently $(__luaver_get_current_lua_version))"
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_lua_version || echo none))"
     'ls' -1 "${__luaver_LUA_DIR}/"
 }
 
@@ -606,7 +606,7 @@ __luaver_uninstall_luajit()
 
 __luaver_list_luajit()
 {
-    __luaver_print "Installed versions: (currently $(__luaver_get_current_luajit_version))"
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_luajit_version || echo none))"
     'ls' -1 "${__luaver_LUAJIT_DIR}/"
 }
 
@@ -730,7 +730,7 @@ __luaver_uninstall_luarocks()
 
 __luaver_list_luarocks()
 {
-    __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version) in lua $(__luaver_get_lua_version_by_current_luarocks))"
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version || echo none) in lua $(__luaver_get_lua_version_by_current_luarocks || echo none))"
     'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v FS=_ '{ print "luarocks-" $1 " (lua version: " $2 ")" }'
 }
 

--- a/luaver
+++ b/luaver
@@ -513,7 +513,7 @@ __luaver_uninstall_lua()
 __luaver_list_lua()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_lua_version || echo none))"
-    'ls' -1 "${__luaver_LUA_DIR}/"
+    'find' "${__luaver_LUA_DIR}"/* -prune | 'awk' -F/ '{ print $NF }'
 }
 
 __luaver_install_luajit()
@@ -607,7 +607,7 @@ __luaver_uninstall_luajit()
 __luaver_list_luajit()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_luajit_version || echo none))"
-    'ls' -1 "${__luaver_LUAJIT_DIR}/"
+    'find' "${__luaver_LUAJIT_DIR}"/* -prune | 'awk' -F/ '{ print $NF }'
 }
 
 __luaver_install_luarocks()
@@ -731,9 +731,7 @@ __luaver_uninstall_luarocks()
 __luaver_list_luarocks()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version || echo none) in lua $(__luaver_get_lua_version_by_current_luarocks || echo none))"
-    # The result can be broken if a non-numeric directory exists in LUAROCKS_DIR
-    # shellcheck disable=SC2012
-    'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v FS=_ '{ print "luarocks-" $1 " (lua version: " $2 ")" }'
+    'find' "${__luaver_LUAROCKS_DIR}/"* -prune | 'awk' -F/ '{ print $NF }' | 'awk' -F_ '{ print $1 "\tlua:" $2}'
 }
 
 __luaver_current()

--- a/luaver
+++ b/luaver
@@ -513,7 +513,7 @@ __luaver_uninstall_lua()
 __luaver_list_lua()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_lua_version || echo none))"
-    'find' "${__luaver_LUA_DIR}"/* -prune | 'awk' -F/ '{ print $NF }'
+    'find' "${__luaver_LUA_DIR}" -name '*.*' -prune | 'awk' -F/ '{ print $NF }'
 }
 
 __luaver_install_luajit()
@@ -607,7 +607,7 @@ __luaver_uninstall_luajit()
 __luaver_list_luajit()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_luajit_version || echo none))"
-    'find' "${__luaver_LUAJIT_DIR}"/* -prune | 'awk' -F/ '{ print $NF }'
+    'find' "${__luaver_LUAJIT_DIR}" -name '*.*' -prune | 'awk' -F/ '{ print $NF }'
 }
 
 __luaver_install_luarocks()
@@ -731,7 +731,7 @@ __luaver_uninstall_luarocks()
 __luaver_list_luarocks()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version || echo none) in lua $(__luaver_get_lua_version_by_current_luarocks || echo none))"
-    'find' "${__luaver_LUAROCKS_DIR}/"* -prune | 'awk' -F/ '{ print $NF }' | 'awk' -F_ '{ print $1 "\tlua:" $2}'
+    'find' "${__luaver_LUAROCKS_DIR}" -name '*.*' -prune | 'awk' -F/ '{ print $NF }' | 'awk' -F_ '{ print $1 "\tlua:" $2}'
 }
 
 __luaver_current()

--- a/luaver
+++ b/luaver
@@ -520,9 +520,6 @@ __luaver_uninstall_lua()
 
 __luaver_list_lua()
 {
-    local current_version
-    current_version=$(__luaver_get_current_lua_version)
-
     if ! [ "$(ls -A "${__luaver_LUA_DIR}/")" ]
     then
         __luaver_print "No version of lua is installed"
@@ -530,17 +527,10 @@ __luaver_list_lua()
     fi
 
     __luaver_print "Installed versions: "
-    # Versions would not have spaces or globs in between
-    # shellcheck disable=SC2045
-    for version in $(ls "${__luaver_LUA_DIR}/")
-    do
-        if [ "${version}" = "${current_version}" ]
-        then
-            __luaver_print "lua-${version} <--"
-        else
-            __luaver_print "lua-${version}"
-        fi
-    done
+    'ls' "${__luaver_LUA_DIR}/" | 'awk' -v current_version="$(__luaver_get_current_lua_version)" '{
+        if ($0 == current_version) { arrow = " <--" } else { arrow = "" }
+        print "lua-" $0 arrow
+    }'
 }
 
 __luaver_install_luajit()
@@ -633,9 +623,6 @@ __luaver_uninstall_luajit()
 
 __luaver_list_luajit()
 {
-    local current_version
-    current_version=$(__luaver_get_current_luajit_version)
-
     if ! [ "$(ls -A "${__luaver_LUAJIT_DIR}/")" ]
     then
         __luaver_print "No version of LuaJIT is installed"
@@ -643,17 +630,10 @@ __luaver_list_luajit()
     fi
 
     __luaver_print "Installed versions: "
-    # Versions would not have spaces or globs in between
-    # shellcheck disable=SC2045
-    for version in $(ls "${__luaver_LUAJIT_DIR}/")
-    do
-        if [ "${version}" = "${current_version}" ]
-        then
-            __luaver_print "LuaJIT-${version} <--"
-        else
-            __luaver_print "LuaJIT-${version}"
-        fi
-    done
+    'ls' "${__luaver_LUAJIT_DIR}/" | 'awk' -v current_version="$(__luaver_get_current_luajit_version)" '{
+        if ($0 == current_version) { arrow = " <--" } else { arrow = "" }
+        print "LuaJIT-" $0 arrow
+    }'
 }
 
 __luaver_install_luarocks()
@@ -776,11 +756,6 @@ __luaver_uninstall_luarocks()
 
 __luaver_list_luarocks()
 {
-    local current_luarocks_version
-    local current_lua_version
-    current_luarocks_version=$(__luaver_get_current_luarocks_version)
-    current_lua_version=$(__luaver_get_lua_version_by_current_luarocks)
-
     if ! [ "$(ls -A "${__luaver_LUAROCKS_DIR}/")" ]
     then
         __luaver_print "No version of luarocks is installed"
@@ -788,20 +763,10 @@ __luaver_list_luarocks()
     fi
 
     __luaver_print "Installed versions: "
-    # Versions would not have spaces or globs in between
-    # shellcheck disable=SC2045
-    for version in $(ls "${__luaver_LUAROCKS_DIR}/")
-    do
-        luarocks_version=${version%_*}
-        lua_version=${version#*_}
-
-        if [ "${luarocks_version}" = "${current_luarocks_version}" ] && [ "${lua_version}" = "${current_lua_version}" ]
-        then
-            __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version}) <--"
-        else
-            __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version})"
-        fi
-    done
+    'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v current_luarocks_version="$(__luaver_get_current_luarocks_version)" -v current_lua_version="$(__luaver_get_lua_version_by_current_luarocks)" -v FS=_ '{
+        if ($1 == current_luarocks_version && $2 == current_lua_version) { arrow = " <--" } else { arrow = "" }
+        print "luarocks-" $1 " (lua version: " $2 ")" arrow
+    }'
 }
 
 __luaver_current()

--- a/luaver
+++ b/luaver
@@ -290,12 +290,10 @@ __luaver_get_current_lua_version()
     if __luaver_exists lua
     then
         version=${version#$__luaver_LUA_DIR/}
-        version=${version%/bin/lua}
+        echo "${version%/bin/lua}"
     else
-        version=""
+        return 1
     fi
-    
-    echo "${version}"
 }
 
 # Returns the current lua version (only the first two numbers)
@@ -320,12 +318,10 @@ __luaver_get_current_luajit_version()
     if __luaver_exists "luajit"
     then
         version=${version#$__luaver_LUAJIT_DIR/}
-        version=${version%/bin/luajit}
+        echo "${version%/bin/luajit}"
     else
-        version=""
+        return 1
     fi
-
-    echo "${version}"
 }
 
 # Returns the current luarocks version
@@ -338,12 +334,10 @@ __luaver_get_current_luarocks_version()
     then
         version=${version#$__luaver_LUAROCKS_DIR/}
         version=${version%/bin/luarocks}
-        version=${version%_*}
+        echo "${version%_*}"
     else
-        version=""
+        return 1
     fi
-
-    echo "${version}"
 }
 
 # Returns the short lua version being supported by present luarocks
@@ -356,12 +350,10 @@ __luaver_get_lua_version_by_current_luarocks()
     then
         version=${version#$__luaver_LUAROCKS_DIR/}
         version=${version%/bin/luarocks}
-        version=${version#*_}
+        echo "${version#*_}"
     else
-        version=""
+        return 1
     fi
-
-    echo "${version}"
 }
 
 # End of Helper functions

--- a/luaver
+++ b/luaver
@@ -731,6 +731,8 @@ __luaver_uninstall_luarocks()
 __luaver_list_luarocks()
 {
     __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version || echo none) in lua $(__luaver_get_lua_version_by_current_luarocks || echo none))"
+    # The result can be broken if a non-numeric directory exists in LUAROCKS_DIR
+    # shellcheck disable=SC2012
     'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v FS=_ '{ print "luarocks-" $1 " (lua version: " $2 ")" }'
 }
 

--- a/luaver
+++ b/luaver
@@ -521,27 +521,26 @@ __luaver_uninstall_lua()
 __luaver_list_lua()
 {
     local current_version
-    local versions
     current_version=$(__luaver_get_current_lua_version)
-    versions=$(ls -A "${__luaver_LUA_DIR}/")
 
-    if [ "${versions}" ]
+    if ! [ "$(ls -A "${__luaver_LUA_DIR}/")" ]
     then
-        __luaver_print "Installed versions: "
-        # Versions would not have spaces or globs in between
-        # shellcheck disable=SC2045
-        for version in $(ls "${__luaver_LUA_DIR}/")
-        do
-            if [ "${version}" = "${current_version}" ]
-            then
-                __luaver_print "lua-${version} <--"
-            else 
-                __luaver_print "lua-${version}"
-            fi
-        done
-    else
         __luaver_print "No version of lua is installed"
+        return 1
     fi
+
+    __luaver_print "Installed versions: "
+    # Versions would not have spaces or globs in between
+    # shellcheck disable=SC2045
+    for version in $(ls "${__luaver_LUA_DIR}/")
+    do
+        if [ "${version}" = "${current_version}" ]
+        then
+            __luaver_print "lua-${version} <--"
+        else
+            __luaver_print "lua-${version}"
+        fi
+    done
 }
 
 __luaver_install_luajit()
@@ -635,27 +634,26 @@ __luaver_uninstall_luajit()
 __luaver_list_luajit()
 {
     local current_version
-    local versions
     current_version=$(__luaver_get_current_luajit_version)
-    versions=$(ls -A "{$__luaver_LUAJIT_DIR}/")
 
-    if [ "${versions}" ]
+    if ! [ "$(ls -A "${__luaver_LUAJIT_DIR}/")" ]
     then
-        __luaver_print "Installed versions: "
-        # Versions would not have spaces or globs in between
-        # shellcheck disable=SC2045
-        for version in $(ls "${__luaver_LUAJIT_DIR}/")
-        do
-            if [ "${version}" = "${current_version}" ]
-            then
-                __luaver_print "LuaJIT-${version} <--"
-            else
-                __luaver_print "LuaJIT-${version}"
-            fi
-        done
-    else
         __luaver_print "No version of LuaJIT is installed"
+        return 1
     fi
+
+    __luaver_print "Installed versions: "
+    # Versions would not have spaces or globs in between
+    # shellcheck disable=SC2045
+    for version in $(ls "${__luaver_LUAJIT_DIR}/")
+    do
+        if [ "${version}" = "${current_version}" ]
+        then
+            __luaver_print "LuaJIT-${version} <--"
+        else
+            __luaver_print "LuaJIT-${version}"
+        fi
+    done
 }
 
 __luaver_install_luarocks()
@@ -780,31 +778,30 @@ __luaver_list_luarocks()
 {
     local current_luarocks_version
     local current_lua_version
-    local versions
     current_luarocks_version=$(__luaver_get_current_luarocks_version)
     current_lua_version=$(__luaver_get_lua_version_by_current_luarocks)
-    versions=$(ls -A "{$__luaver_LUAROCKS_DIR}/")
 
-    if [ "${versions}" ]
+    if ! [ "$(ls -A "${__luaver_LUAROCKS_DIR}/")" ]
     then
-        __luaver_print "Installed versions: "
-        # Versions would not have spaces or globs in between
-        # shellcheck disable=SC2045
-        for version in $(ls "${__luaver_LUAROCKS_DIR}/")
-        do
-            luarocks_version=${version%_*}
-            lua_version=${version#*_}
-
-            if [ "${luarocks_version}" = "${current_luarocks_version}" ] && [ "${lua_version}" = "${current_lua_version}" ]
-            then
-                __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version}) <--"
-            else
-                __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version})"
-            fi
-        done
-    else
         __luaver_print "No version of luarocks is installed"
+        return 1
     fi
+
+    __luaver_print "Installed versions: "
+    # Versions would not have spaces or globs in between
+    # shellcheck disable=SC2045
+    for version in $(ls "${__luaver_LUAROCKS_DIR}/")
+    do
+        luarocks_version=${version%_*}
+        lua_version=${version#*_}
+
+        if [ "${luarocks_version}" = "${current_luarocks_version}" ] && [ "${lua_version}" = "${current_lua_version}" ]
+        then
+            __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version}) <--"
+        else
+            __luaver_print "luarocks-${luarocks_version} (lua version: ${lua_version})"
+        fi
+    done
 }
 
 __luaver_current()

--- a/luaver
+++ b/luaver
@@ -520,17 +520,8 @@ __luaver_uninstall_lua()
 
 __luaver_list_lua()
 {
-    if ! [ "$(ls -A "${__luaver_LUA_DIR}/")" ]
-    then
-        __luaver_print "No version of lua is installed"
-        return 1
-    fi
-
-    __luaver_print "Installed versions: "
-    'ls' "${__luaver_LUA_DIR}/" | 'awk' -v current_version="$(__luaver_get_current_lua_version)" '{
-        if ($0 == current_version) { arrow = " <--" } else { arrow = "" }
-        print "lua-" $0 arrow
-    }'
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_lua_version))"
+    'ls' -1 "${__luaver_LUA_DIR}/"
 }
 
 __luaver_install_luajit()
@@ -623,17 +614,8 @@ __luaver_uninstall_luajit()
 
 __luaver_list_luajit()
 {
-    if ! [ "$(ls -A "${__luaver_LUAJIT_DIR}/")" ]
-    then
-        __luaver_print "No version of LuaJIT is installed"
-        return 1
-    fi
-
-    __luaver_print "Installed versions: "
-    'ls' "${__luaver_LUAJIT_DIR}/" | 'awk' -v current_version="$(__luaver_get_current_luajit_version)" '{
-        if ($0 == current_version) { arrow = " <--" } else { arrow = "" }
-        print "LuaJIT-" $0 arrow
-    }'
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_luajit_version))"
+    'ls' -1 "${__luaver_LUAJIT_DIR}/"
 }
 
 __luaver_install_luarocks()
@@ -756,17 +738,8 @@ __luaver_uninstall_luarocks()
 
 __luaver_list_luarocks()
 {
-    if ! [ "$(ls -A "${__luaver_LUAROCKS_DIR}/")" ]
-    then
-        __luaver_print "No version of luarocks is installed"
-        return 1
-    fi
-
-    __luaver_print "Installed versions: "
-    'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v current_luarocks_version="$(__luaver_get_current_luarocks_version)" -v current_lua_version="$(__luaver_get_lua_version_by_current_luarocks)" -v FS=_ '{
-        if ($1 == current_luarocks_version && $2 == current_lua_version) { arrow = " <--" } else { arrow = "" }
-        print "luarocks-" $1 " (lua version: " $2 ")" arrow
-    }'
+    __luaver_print "Installed versions: (currently $(__luaver_get_current_luarocks_version) in lua $(__luaver_get_lua_version_by_current_luarocks))"
+    'ls' "${__luaver_LUAROCKS_DIR}/" | 'awk' -v FS=_ '{ print "luarocks-" $1 " (lua version: " $2 ")" }'
 }
 
 __luaver_current()


### PR DESCRIPTION
`for f in $(ls directory)` is fragile in two ways:

## Broken if ls is aliased

```
$ touch 5.1.1 5.1.2
$ alias ls='ls -l'
$ for f in $(ls .); do echo lua-$f; done
lua-total
lua-0
lua--rw-r--r--
lua-1
lua-umireon
lua-staff
lua-0
lua-Jan
lua-11
lua-21:26
lua-1
lua--rw-r--r--
lua-1
lua-umireon
lua-staff
lua-0
lua-Jan
lua-11
lua-21:26
lua-2
```

## Broken if `IFS` is changed

```
$ touch 5.1.1 5.1.2
$ IFS=.
$ for f in $(ls .); do echo lua-$f; done
lua-5
lua-2
lua-1
5
lua-2
lua-2
```

This PR fix these problems.

Note that the output format is slightly changed to keep it simple, stupid (KISS).
IMO this strategy is good to reduce bugs and improve portability.
Original format can be retained as 479f0ac, but this (and the original implementation) may be unneededly complex.

```
$ luaver list
==>  Installed versions: (currently 5.3.1)
5.3.1
5.3.2
```

## Changeset Description
* Prefer `find` than `ls` ([SC2012](https://github.com/koalaman/shellcheck/wiki/SC2012))
* Remove fragile `for f in $(ls ...)` ([SC2045](https://github.com/koalaman/shellcheck/wiki/SC2045), the `IFS` problem)
* Bypass alias by quoting commands ([POSIX 2004](http://pubs.opengroup.org/onlinepubs/009696899/utilities/xcu_chap02.html#tag_02_03_01)).