### PR TITLE
Simplify the description of git installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/src/
+/lua/
+/luajit/
+/luarocks/
+/DEFAULT*

--- a/README.md
+++ b/README.md
@@ -41,20 +41,35 @@ curl https://raw.githubusercontent.com/dhavalkapil/luaver/v1.0.0/install.sh -o i
 
 _Note: It will overwrite any `install.sh` in your current directory. Also, this file is no longer needed after the installation is complete._
 
-### Installation from Git Repository
+### Install using `git`
 
-First clone `luaver` on your local machine using git:
+1. Clone this repository into `~/.luaver`:
 
-```sh
-git clone https://github.com/DhavalKapil/luaver
+    ```sh
+    $ git clone https://github.com/DhavalKapil/luaver.git ~/.luaver
+    ```
+
+2. Add `. ~/.luaver/luaver` to your `.bashrc` or equivalent:
+
+    ```sh
+    $ echo ". ~/.luaver/luaver" >> ~/.bashrc
+    ```
+
+3. Reload `.bashrc` or restart the shell to load `luaver`:
+
+   ```sh
+   $ . ~/.bashrc
+   ```
+
+### Update using `git`
+
+_Note: This method only works if luaver was installed using `git`._
+
+```
+$ cd ~/.luaver && git fetch origin && git reset --hard origin/master
 ```
 
-Then, run the installation script:
-
-```sh
-cd luaver
-. ./install.sh
-```
+Additional works may be required.
 
 ## Usage
 


### PR DESCRIPTION
`install.sh` is not required for git-based installation.

The current `install.sh` provides the two major feature and minor cleanups:

* Download `luaver` using `wget`.
* Append `. ~/.luaver/luaver` to the `.bashrc` or `.zshrc`
* build thedirectory structure (meaningless because `luaver` does it)

In git installation, the first feature is not needed because git actually downloads `luaver`.
The second feature is also not so helpful for users who uses git that they should be familiar with CLI.
In addition, the installation script hides the mechanics how `luaver` cooperate with shell, which prevents users to understand how `luaver` works.

Disclosing the installation process may also be helpful for Homebrew users as indicated in #11, #21.