### PR TITLE
Add the completion for bash

### DIFF
--- a/completions/luaver.bash
+++ b/completions/luaver.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+_luaver_download()
+{
+    if curl -V >/dev/null 2>&1
+    then
+        curl -fsSL "$1"
+    else
+        wget -qO- "$1"
+    fi
+}
+
+_luaver()
+{
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local opts
+    case $COMP_CWORD in
+        1 )
+            opts=($(luaver help | 'awk' '/^   / { print $2 }')) # UGLY HACK
+            ;;
+        2 )
+            case ${COMP_WORDS[COMP_CWORD-1]} in
+                install )
+                    opts=($(_luaver_download "https://www.lua.org/ftp/" | 'awk' 'match($0, /lua-5\.[0-9]+(\.[0-9]+)?/) { print substr($0, RSTART + 4, RLENGTH - 4) }'))
+                    ;;
+                install-luajit )
+                    opts=($(_luaver_download "http://luajit.org/download.html" | awk '/MD5 Checksums/,/<\/pre/ { print }' | awk '/LuaJIT.*gz/ { print $2 }' | sed -e s/LuaJIT-// -e s/\.tar\.gz//))
+                    ;;
+                install-luarocks )
+                    opts=($(wget -qO- http://luarocks.github.io/luarocks/releases/releases.json | 'awk' 'match($0, /"[0-9]+\.[0-9]\.[0-9]"/) { print substr($0, RSTART, RLENGTH) } '))
+                    ;;
+                use | set-default | uninstall)
+                    opts=($(luaver list | grep '[0-9].[0-9].[0-9]' | tr - ' ')) # UGLY HACK
+                    ;;
+                use-luajit | set-default-luajit | uninstall-luajit )
+                    opts=($(luaver list-luajit | grep '[0-9].[0-9].[0-9]' | tr - ' ')) # UGLY HACK
+                    ;;
+                use-luarocks | set-default-luarocks | uninstall-luarocks)
+                    opts=($(luaver list-luarocks | grep '[0-9].[0-9].[0-9]' | tr - ' ')) # UGLY HACK
+                    ;;
+            esac
+            ;;
+    esac
+    COMPREPLY=($(compgen -W "${opts[*]}" -- "$cur"))
+}
+
+complete -F _luaver luaver


### PR DESCRIPTION
This bash completion will be helpful for those who are lazy to type or who could not remember the version number of the latest Lua distribution as seen in #22.

```
$ . ~/.luaver/completion/luaver.bash
$ luaver[TAB]
current                 list-luarocks           unset-default
help                    set-default             unset-default-luajit
install                 set-default-luajit      unset-default-luarocks
install-luajit          set-default-luarocks    use
install-luarocks        uninstall               use-luajit
list                    uninstall-luajit        use-luarocks
list-luajit             uninstall-luarocks      version
$ luaver install 5.[TAB]
5.0    5.0.2  5.1    5.1.2  5.1.4  5.2.0  5.2.2  5.2.4  5.3.1  5.3.3
5.0.1  5.0.3  5.1.1  5.1.3  5.1.5  5.2.1  5.2.3  5.3.0  5.3.2
$ luaver install 5.1.[TAB]
5.1.1  5.1.2  5.1.3  5.1.4  5.1.5
```

## Future Improvement (TODO)
* Completions with install command are painfully slow.
* list commands should be modified for machine readability.