### PR TITLE
Make luaver executable

### DIFF
--- a/luaver
+++ b/luaver
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Lua Version Manager
 # Managing and switching between different versions of Lua, LuaJIT and Luarocks made easy
 #
@@ -856,3 +857,5 @@ luaver()
 
     __luaver_exec_command "cd ${__luaver_present_dir}"
 }
+
+[ -n "$1" ] && luaver "$@"


### PR DESCRIPTION
By this change, luaver can be used as a simple Lua installer.

```
$ ./luaver install 5.3.2
```

This feature is especially useful when the interactive shell is not a POSIX-compliant like fish and csh.